### PR TITLE
52-profiles-lock

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -3,7 +3,11 @@ class ProfilesController < ApplicationController
 
   # GET /profiles
   def index
-    @profiles = Profile.all
+    if current_user.has_edit_permission
+      @profiles = Profile.all
+    else
+      redirect_to root_path, notice: 'You do not have permission to view that page.'
+    end
   end
 
   # GET /profiles/1

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160725192335) do
+ActiveRecord::Schema.define(version: 20160728164359) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Fixes #52 

Adds redirect if current user does not have edit (admin level) permissions

---
### Login Credentials

Your own GitHub account

---
### Functionality to test

In `rails console` check whether your User object `#has_edit_permission`.
- [ ] if `#has_edit_permission => false` attempting to go to the path **localhost:3000/profiles** should redirect you to the root_path
- [ ] if `#has_edit_permission => true` attempting to go to the path **localhost:3000/profiles** should show you an index of all profiles for the application
