### PR TITLE
56 position end date should allow nil

### DIFF
--- a/app/views/positions/_form.html.erb
+++ b/app/views/positions/_form.html.erb
@@ -31,11 +31,11 @@
   </div>
   <div class="field">
     <%= f.label :start_date %><br>
-    <%= f.datetime_select :start_date %>
+    <%= f.datetime_select :start_date, :include_blank => true %>
   </div>
   <div class="field">
     <%= f.label :end_date %><br>
-    <%= f.datetime_select :end_date %>
+    <%= f.datetime_select :end_date, :include_blank => true %>
   </div>
   <div class="actions">
     <%= f.submit %>


### PR DESCRIPTION
Fixes #56 

---
### Functionality to Test
- The user should be able to leave the date/time select blank.  They can successfully do this, however, it should be noted that the field now displays vertically.  This seems a styling issue rather than a functionality issue though.
