### PR TITLE
108 alter no profile error

### DIFF
--- a/app/views/application/_default_sidebar.html.erb
+++ b/app/views/application/_default_sidebar.html.erb
@@ -17,10 +17,12 @@
           <%= fa_icon("exclamation-triangle") %>
           No Candidate Profile
         </p>
-        <p class="sidebarAlert__text">
-          You need to
-          <%= link_to "add links to your latest résumé and LinkedIn", :update_profile %>.
-        </p>
+        <% if user == current_user %>
+          <p class="sidebarAlert__text">
+            You need to
+            <%= link_to "add links to your latest résumé and LinkedIn", :update_profile %>.
+          </p>
+        <% end %>
       </div>
     <% else %>
       <%= link_to fa_icon("file-text-o", text: "Résumé"), user.resume, class: "userInfo__socialLink", :target => "_blank"  %>


### PR DESCRIPTION
Fixes #108 

---
### Login Credentials

Your GH profile. You should be able to create a new Job Application (that might mean being a "student" User)

---
### Functionality to Test
- [ ] If you view one of your own application Entry page's and do not have a candidate profile, you will see an error box with an invitation to add in the candidate profile information
- [ ] If you view the application Entry page of another User who does not have a candidate profile, you will see a message to that effect with no link to add in info.
