### PR TITLE
136 Application Breaks on Position Creation

### DIFF
--- a/app/views/entries/show.html.erb
+++ b/app/views/entries/show.html.erb
@@ -54,7 +54,7 @@
 <% if @entry.position %>
   <h2>Position</h2>
   <p>
-    You accepted a position at the <%= @entry.position.location %> location as a <%= @entry.position.job_title %>, earning <%= number_to_currency(@entry.position.salary.pretty_amount, precision: 0) %> (<%= @entry.position.salary.rate %>) about <%= time_ago_in_words(@position.offer.created_at) %> ago. <%= "This is a remote position." if @position.offer.remote %> Congratulations!
+    You accepted a position at the <%= @entry.position.location %> location as a <%= @entry.position.job_title %>, earning <%= number_to_currency(@entry.position.salary.amount, precision: 0) %> (<%= @entry.position.salary.rate %>) about <%= time_ago_in_words(@entry.position.created_at) %> ago. <%= "This is a remote position." if @entry.position.remote %> Congratulations!
   </p>
   <!-- <%# @entry.position.job_title %> <%# @entry.position.location %><br>
   <%# link_to 'See more...', @entry.position %><br><br> -->

--- a/app/views/positions/_form.html.erb
+++ b/app/views/positions/_form.html.erb
@@ -32,6 +32,7 @@
     <p>
       <%= ff.label :amount, "Salary/Rate" %><br>
       <%= ff.text_field :amount, placeholder: "49,000 or 20/hr" %>
+      <%= ff.select(:rate, options_for_select(Salary.rates.keys, "hourly")) %>
     </p>
   <% end %>
 


### PR DESCRIPTION
Fixes #136

...which was related to some careless editing on my part on the Entry show page

---
### Login Credentials

Your GH profile. You should be able to create a new Job Application (that might mean being a "student" User)

---
### Functionality to Test
- [x] After a Job Application is "leveled up" to a Position, you will be redirected successfully to the Entry show page and the application will not break.
